### PR TITLE
th/logout-flow

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,7 +1,37 @@
 import Image from "next/image";
 import { ConnectKitButton } from "connectkit";
+import { useEffect } from "react";
+import { useAccount } from "wagmi";
+import { useAuth } from "@/hooks/useAuth";
 
 const Navbar = () => {
+  const { isDisconnected } = useAccount();
+  const { isLoggedIn, logout } = useAuth();
+
+  // Logout when a user changes their wallet in their browser extension
+  useEffect(() => {
+    const handleAccountsChanged = async () => {
+      await logout();
+    }
+
+    if (!!window.ethereum) {
+      //@ts-ignore
+      window.ethereum?.on('accountsChanged', handleAccountsChanged)
+    }
+
+    return () => {
+      //@ts-ignore
+      window.ethereum?.removeListener('accountsChanged', handleAccountsChanged)
+    }
+  }, [logout]) // eslint-disable-line
+
+  // Logout when a user disconnects their wallet from the connectKit provider
+  useEffect(() => {
+    if (isDisconnected) {
+      logout();
+    }
+  }, [isDisconnected]); // eslint-disable-line
+
   return (
     <main className="pt-8">
       <section className="max-w-screen-xl mx-auto">

--- a/hooks/useAuth.tsx
+++ b/hooks/useAuth.tsx
@@ -1,4 +1,4 @@
-import { useContext, createContext, ReactNode, useState, useEffect } from "react";
+import { useContext, createContext, ReactNode, useState, useEffect, useCallback } from "react";
 import { useAccount, useNetwork, useSignMessage } from 'wagmi'
 import { SiweMessage } from "siwe";
 
@@ -101,17 +101,21 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     } catch (error) {
       setState((x) => ({ ...x, loading: false, nonce: undefined, error: error as Error }))
       fetchNonce()
+      return { success: false }
     }
   }
 
-  const logout = async () => {
+  const logout = useCallback(async () => {
     try {
-      await fetch('/api/logout')
-      setState({})
+      if (state.currentUser) {
+        await fetch('/api/logout')
+        setState({})
+        fetchNonce()
+      }
     } catch (_error) {
       setState({})
     }
-  };
+  }, [state.currentUser]);
 
   return (
     <AuthContext.Provider

--- a/lib/apollo.ts
+++ b/lib/apollo.ts
@@ -10,7 +10,7 @@ const defaultLink = new HttpLink({
 });
 
 const nounsDAOLink = new HttpLink({
-  uri: 'https://api.thegraph.com/subgraphs/name/nounsdao/nouns-subgraph',
+  uri: 'https://api.goldsky.com/api/public/project_cldf2o9pqagp43svvbk5u3kmo/subgraphs/nouns/0.1.0/gn',
 });
 
 const lilNounsDAOLink = new HttpLink({


### PR DESCRIPTION
PR to ensure users logout when switching wallets or disconnecting their wallet. Don't want to allow users to swap wallets and still be authenticated, i don't think users could manipulate this anyway but better to be safe.

Also updated the nouns hosted subgraph api link as them and lilnouns are moving away from hosting on The Graph. The queries are still identical so shouldn't be any issues.