### PR TITLE
Add missing prisma dependency

### DIFF
--- a/pages/api/graphql.ts
+++ b/pages/api/graphql.ts
@@ -4,8 +4,8 @@ import { ironOptions } from "@/lib/config";
 
 import { ApolloServer } from "@apollo/server";
 import { startServerAndCreateNextHandler } from "@as-integrations/next";
-import { SUPPORTED_SUBDOMAINS, SupportedTokenGetterMap } from "@/utils/supportedTokenUtils";
 import getCommunityByDomain from "@/utils/communityByDomain";
+import prisma from "@/lib/prisma";
 
 // @ts-ignore
 const server = new ApolloServer({


### PR DESCRIPTION
Prod is failing with `Context creation failed: prisma is not defined` as we're not importing the prisma reference when creating the graphql server. This works locally as prisma is stored to a global reference;