### PR TITLE
Th/fix comment behaviour

### DIFF
--- a/components/Comment.tsx
+++ b/components/Comment.tsx
@@ -70,6 +70,16 @@ const Comment = ({
 
   const commentData = deletedComment?.deleteIdeaComment || comment;
 
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  if (!isMounted) {
+    return null
+  }
+
   return (
     <div key={commentData.id}>
       {!commentData.deleted ? (

--- a/components/CommentInput.tsx
+++ b/components/CommentInput.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { createBreakpoint } from "react-use";
 import { Button, FormControl } from "react-bootstrap";
 import { useMutation } from "@apollo/client";
@@ -31,7 +31,7 @@ const CommentInput = ({
     context: {
       clientName: "PropLot",
     },
-    refetchQueries: ["getIdea"],
+    refetchQueries: ["getIdeaComments"],
   });
 
   const getCommentMutationArgs = (
@@ -77,6 +77,16 @@ const CommentInput = ({
     }
     setCommentValue("");
   };
+
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  if (!isMounted) {
+    return null
+  }
 
   return (
     <div className="relative mt-4">

--- a/graphql/queries/ideaQuery.ts
+++ b/graphql/queries/ideaQuery.ts
@@ -20,11 +20,35 @@ export const GET_IDEA_QUERY = gql`
         type
         label
       }
-      comments {
+      votes {
+        id
+        voterId
+        ideaId
+        direction
+        voterWeight
+        voter {
+          wallet
+        }
+      }
+    }
+  }
+`;
+
+export const GET_IDEA_COMMENTS = gql`
+  query getIdeaComments($ideaId: Int!) {
+    getIdeaComments(options: { ideaId: $ideaId }) {
+      body
+      id
+      parentId
+      deleted
+      ideaId
+      createdAt
+      authorId
+      replies {
         body
         id
-        parentId
         deleted
+        parentId
         ideaId
         createdAt
         authorId
@@ -36,25 +60,6 @@ export const GET_IDEA_QUERY = gql`
           ideaId
           createdAt
           authorId
-          replies {
-            body
-            id
-            deleted
-            parentId
-            ideaId
-            createdAt
-            authorId
-          }
-        }
-      }
-      votes {
-        id
-        voterId
-        ideaId
-        direction
-        voterWeight
-        voter {
-          wallet
         }
       }
     }

--- a/graphql/resolvers/IdeaResolvers.ts
+++ b/graphql/resolvers/IdeaResolvers.ts
@@ -12,6 +12,7 @@ import {
   Comment,
   MutationDeleteIdeaArgs,
   DeleteDataResponse,
+  QueryGetIdeaCommentsArgs,
 } from "@/graphql/types/__generated__/apiTypes";
 import { TagType } from "@prisma/client";
 
@@ -36,6 +37,13 @@ const resolvers: IResolvers = {
         sortBy: args.options.sort as string,
       });
       return ideas;
+    },
+    getIdeaComments: async (
+      _parent: any,
+      args: QueryGetIdeaCommentsArgs
+    ): Promise<Comment[]> => {
+      const comments: Comment[] = await IdeasService.getIdeaComments(args.options.ideaId as number);
+      return comments;
     },
   },
   Mutation: {

--- a/graphql/schemas/schema.graphql
+++ b/graphql/schemas/schema.graphql
@@ -3,6 +3,7 @@ scalar Date
 type Query {
   getIdea(options: IdeaInputOptions!): Idea
   getIdeas(options: IdeaInputOptions!): [Idea!]
+  getIdeaComments(options: IdeaCommentInputOptions!): [Comment!]
   getAllUsers: [User!]
   getUser(options: UserInputOptions!): User
   getPropLot(options: PropLotInputOptions!): PropLotResponse!
@@ -27,6 +28,10 @@ input UserInputOptions {
 input IdeaInputOptions {
   ideaId: Int
   sort: SORT_TYPE
+}
+
+input IdeaCommentInputOptions {
+  ideaId: Int!
 }
 
 input SubmitVoteInputOptions {

--- a/graphql/types/__generated__/apiTypes.ts
+++ b/graphql/types/__generated__/apiTypes.ts
@@ -84,6 +84,10 @@ export type Idea = {
   votes?: Maybe<Array<Vote>>;
 };
 
+export type IdeaCommentInputOptions = {
+  ideaId: Scalars['Int'];
+};
+
 export type IdeaInputOptions = {
   ideaId?: InputMaybe<Scalars['Int']>;
   sort?: InputMaybe<Sort_Type>;
@@ -166,6 +170,7 @@ export type PropLotProfileResponse = {
 
 export type PropLotResponse = {
   __typename?: 'PropLotResponse';
+  appliedFilterTags?: Maybe<Array<AppliedFilter>>;
   dateFilter?: Maybe<PropLotFilter>;
   ideas?: Maybe<Array<Idea>>;
   metadata: PropLotResponseMetadata;
@@ -176,7 +181,6 @@ export type PropLotResponse = {
 export type PropLotResponseMetadata = {
   __typename?: 'PropLotResponseMetadata';
   appliedFilters?: Maybe<Array<Scalars['String']>>;
-  filterControls?: Maybe<Array<AppliedFilter>>;
   requestUUID: Scalars['String'];
 };
 
@@ -189,6 +193,7 @@ export type Query = {
   __typename?: 'Query';
   getAllUsers?: Maybe<Array<User>>;
   getIdea?: Maybe<Idea>;
+  getIdeaComments?: Maybe<Array<Comment>>;
   getIdeas?: Maybe<Array<Idea>>;
   getPropLot: PropLotResponse;
   getPropLotProfile: PropLotProfileResponse;
@@ -198,6 +203,11 @@ export type Query = {
 
 export type QueryGetIdeaArgs = {
   options: IdeaInputOptions;
+};
+
+
+export type QueryGetIdeaCommentsArgs = {
+  options: IdeaCommentInputOptions;
 };
 
 
@@ -372,6 +382,7 @@ export type ResolversTypes = {
   FilterType: FilterType;
   Float: ResolverTypeWrapper<Scalars['Float']>;
   Idea: ResolverTypeWrapper<Idea>;
+  IdeaCommentInputOptions: IdeaCommentInputOptions;
   IdeaInputOptions: IdeaInputOptions;
   IdeaStats: ResolverTypeWrapper<IdeaStats>;
   IdeaTags: ResolverTypeWrapper<IdeaTags>;
@@ -409,6 +420,7 @@ export type ResolversParentTypes = {
   FilterOption: FilterOption;
   Float: Scalars['Float'];
   Idea: Idea;
+  IdeaCommentInputOptions: IdeaCommentInputOptions;
   IdeaInputOptions: IdeaInputOptions;
   IdeaStats: IdeaStats;
   IdeaTags: IdeaTags;
@@ -541,6 +553,7 @@ export type PropLotProfileResponseResolvers<ContextType = any, ParentType extend
 };
 
 export type PropLotResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['PropLotResponse'] = ResolversParentTypes['PropLotResponse']> = {
+  appliedFilterTags?: Resolver<Maybe<Array<ResolversTypes['AppliedFilter']>>, ParentType, ContextType>;
   dateFilter?: Resolver<Maybe<ResolversTypes['PropLotFilter']>, ParentType, ContextType>;
   ideas?: Resolver<Maybe<Array<ResolversTypes['Idea']>>, ParentType, ContextType>;
   metadata?: Resolver<ResolversTypes['PropLotResponseMetadata'], ParentType, ContextType>;
@@ -551,7 +564,6 @@ export type PropLotResponseResolvers<ContextType = any, ParentType extends Resol
 
 export type PropLotResponseMetadataResolvers<ContextType = any, ParentType extends ResolversParentTypes['PropLotResponseMetadata'] = ResolversParentTypes['PropLotResponseMetadata']> = {
   appliedFilters?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
-  filterControls?: Resolver<Maybe<Array<ResolversTypes['AppliedFilter']>>, ParentType, ContextType>;
   requestUUID?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -564,6 +576,7 @@ export type PropLotUserProfileResolvers<ContextType = any, ParentType extends Re
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
   getAllUsers?: Resolver<Maybe<Array<ResolversTypes['User']>>, ParentType, ContextType>;
   getIdea?: Resolver<Maybe<ResolversTypes['Idea']>, ParentType, ContextType, RequireFields<QueryGetIdeaArgs, 'options'>>;
+  getIdeaComments?: Resolver<Maybe<Array<ResolversTypes['Comment']>>, ParentType, ContextType, RequireFields<QueryGetIdeaCommentsArgs, 'options'>>;
   getIdeas?: Resolver<Maybe<Array<ResolversTypes['Idea']>>, ParentType, ContextType, RequireFields<QueryGetIdeasArgs, 'options'>>;
   getPropLot?: Resolver<ResolversTypes['PropLotResponse'], ParentType, ContextType, RequireFields<QueryGetPropLotArgs, 'options'>>;
   getPropLotProfile?: Resolver<ResolversTypes['PropLotProfileResponse'], ParentType, ContextType, RequireFields<QueryGetPropLotProfileArgs, 'options'>>;

--- a/graphql/types/__generated__/getIdea.ts
+++ b/graphql/types/__generated__/getIdea.ts
@@ -20,41 +20,6 @@ export interface getIdea_getIdea_tags {
   label: string;
 }
 
-export interface getIdea_getIdea_comments_replies_replies {
-  __typename: "Comment";
-  body: string;
-  id: number;
-  deleted: boolean;
-  parentId: number | null;
-  ideaId: number;
-  createdAt: any;
-  authorId: string;
-}
-
-export interface getIdea_getIdea_comments_replies {
-  __typename: "Comment";
-  body: string;
-  id: number;
-  deleted: boolean;
-  parentId: number | null;
-  ideaId: number;
-  createdAt: any;
-  authorId: string;
-  replies: getIdea_getIdea_comments_replies_replies[] | null;
-}
-
-export interface getIdea_getIdea_comments {
-  __typename: "Comment";
-  body: string;
-  id: number;
-  parentId: number | null;
-  deleted: boolean;
-  ideaId: number;
-  createdAt: any;
-  authorId: string;
-  replies: getIdea_getIdea_comments_replies[] | null;
-}
-
 export interface getIdea_getIdea_votes_voter {
   __typename: "User";
   wallet: string;
@@ -84,7 +49,6 @@ export interface getIdea_getIdea {
   closed: boolean;
   consensus: number | null;
   tags: getIdea_getIdea_tags[] | null;
-  comments: getIdea_getIdea_comments[] | null;
   votes: getIdea_getIdea_votes[] | null;
 }
 

--- a/graphql/types/__generated__/getIdeaComments.ts
+++ b/graphql/types/__generated__/getIdeaComments.ts
@@ -1,0 +1,51 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: getIdeaComments
+// ====================================================
+
+export interface getIdeaComments_getIdeaComments_replies_replies {
+  __typename: "Comment";
+  body: string;
+  id: number;
+  deleted: boolean;
+  parentId: number | null;
+  ideaId: number;
+  createdAt: any;
+  authorId: string;
+}
+
+export interface getIdeaComments_getIdeaComments_replies {
+  __typename: "Comment";
+  body: string;
+  id: number;
+  deleted: boolean;
+  parentId: number | null;
+  ideaId: number;
+  createdAt: any;
+  authorId: string;
+  replies: getIdeaComments_getIdeaComments_replies_replies[] | null;
+}
+
+export interface getIdeaComments_getIdeaComments {
+  __typename: "Comment";
+  body: string;
+  id: number;
+  parentId: number | null;
+  deleted: boolean;
+  ideaId: number;
+  createdAt: any;
+  authorId: string;
+  replies: getIdeaComments_getIdeaComments_replies[] | null;
+}
+
+export interface getIdeaComments {
+  getIdeaComments: getIdeaComments_getIdeaComments[] | null;
+}
+
+export interface getIdeaCommentsVariables {
+  ideaId: number;
+}


### PR DESCRIPTION
My previous [PR](https://github.com/prop-lot/client/pull/32) to fix routing on incorrect domains broke commenting on the idea page. Comments work but the page doesn't update with the new UI. This is due to relying on refetching queries which doesn't work when the initial query happened on the SSR.

This PR adds a query to fetch comments by idea ids and fetches this after the SSR of the idea page. Comments render once the client has loaded and allows us to refetch the query every time a comment is left.