### PR TITLE
Th/fix idea page

### DIFF
--- a/graphql/queries/commentsQuery.ts
+++ b/graphql/queries/commentsQuery.ts
@@ -1,0 +1,33 @@
+import { gql } from "@apollo/client";
+
+export const GET_IDEA_COMMENTS = gql`
+  query getIdeaComments($ideaId: Int!) {
+    getIdeaComments(options: { ideaId: $ideaId }) {
+      body
+      id
+      parentId
+      deleted
+      ideaId
+      createdAt
+      authorId
+      replies {
+        body
+        id
+        deleted
+        parentId
+        ideaId
+        createdAt
+        authorId
+        replies {
+          body
+          id
+          deleted
+          parentId
+          ideaId
+          createdAt
+          authorId
+        }
+      }
+    }
+  }
+`;

--- a/graphql/queries/ideaQuery.ts
+++ b/graphql/queries/ideaQuery.ts
@@ -33,35 +33,3 @@ export const GET_IDEA_QUERY = gql`
     }
   }
 `;
-
-export const GET_IDEA_COMMENTS = gql`
-  query getIdeaComments($ideaId: Int!) {
-    getIdeaComments(options: { ideaId: $ideaId }) {
-      body
-      id
-      parentId
-      deleted
-      ideaId
-      createdAt
-      authorId
-      replies {
-        body
-        id
-        deleted
-        parentId
-        ideaId
-        createdAt
-        authorId
-        replies {
-          body
-          id
-          deleted
-          parentId
-          ideaId
-          createdAt
-          authorId
-        }
-      }
-    }
-  }
-`;

--- a/pages/profile/[id].tsx
+++ b/pages/profile/[id].tsx
@@ -70,7 +70,6 @@ const ProfileUserName = () => {
   const { data: creatorEns } = useEnsName({
     address: id as `0x${string}`,
     cacheTime: 6_000,
-    suspense: true,
   });
   const shortAddress = useShortAddress(id);
 


### PR DESCRIPTION
The idea page was crashing due to the useENS hook from the WAGMI dependency. It seems to crash when the `suspense` property is true, we don't actually need this so i'm removing it. The description of the property is:

> If set to true, the query will suspend when status === 'loading' and throw errors when status === 'error'. Defaults to false.

I can't actually see why it was causing the crash as I can't see any errors being logged and the ens name seems to resolve ok.

I was consistently able to replicate the broken behaviour in incognito windows though and removing this property removed the issue.