### PR TITLE
Add migrations to remove index property. Minor UI cleanup.

### DIFF
--- a/components/IdeaRow.tsx
+++ b/components/IdeaRow.tsx
@@ -95,7 +95,6 @@ const IdeaRow = ({
       <div className="font-propLot font-bold text-[18px] flex flex-row flex-1 justify-content-between align-items-start">
         <span className="flex flex-col sm:flex-row text-[#8C8D92] overflow-hidden">
           <span className="flex flex-row flex-1 justify-content-start align-items-start">
-            <span className="mr-4">{id}</span>
             <span className="truncate">{creatorEns || shortAddress}</span>
           </span>
           <div className="flex flex-row flex-1 justify-content-start align-items-start pt-[16px]">
@@ -145,7 +144,6 @@ const IdeaRow = ({
       <div className="flex flex-1 flex-col">
         <div className="flex flex-1">
           <span className="flex text-[#8C8D92] overflow-hidden">
-            <span className="mr-[8px] w-[48px]">{id}</span>
             <span className="truncate mr-[8px] w-[134px]">
               {creatorEns || shortAddress}
             </span>

--- a/pages/idea/[id].tsx
+++ b/pages/idea/[id].tsx
@@ -125,6 +125,8 @@ const IdeaPage = ({
   const creatorTokenWeight = data.getIdea.votes?.find(
     (vote) => vote.voterId === data.getIdea?.creatorId
   )?.voterWeight;
+  const commentCount = commentData?.getIdeaComments?.filter((c: any) => !c.deleted)
+  ?.length;
 
   return (
     <Container fluid={"lg"} className="mt-8 mb-12">
@@ -219,12 +221,8 @@ const IdeaPage = ({
 
           <div className="mt-2 mb-2">
             <h3 className="text-2xl lodrina font-bold">
-              {
-                commentData?.getIdeaComments?.filter((c: any) => !!c.deleted)
-                  ?.length
-              }{" "}
-              {commentData?.getIdeaComments?.filter((c: any) => !!c.deleted)
-                ?.length === 1
+              {commentCount}{" "}
+              {commentCount === 1
                 ? "comment"
                 : "comments"}
             </h3>

--- a/prisma/migrations/20230526222634_remove_index_from_idea/migration.sql
+++ b/prisma/migrations/20230526222634_remove_index_from_idea/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `index` on the `Idea` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "Idea_communityId_index_key";
+
+-- AlterTable
+ALTER TABLE "Idea" DROP COLUMN "index";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,7 +31,6 @@ model Idea {
   createdAtBlock        Int       @default(0)
   legacyLockedScore     Int       @default(0) // legacy score from old system
   deleted               Boolean   @default(value: false)
-  index                 Int       // index of idea in community
   createdBy             User      @relation(fields: [creatorId], references: [wallet])
   creatorId             String
   community             Community @relation(fields: [communityId], references: [id], onDelete: Cascade)
@@ -39,8 +38,6 @@ model Idea {
   comments              Comment[]
   votes                 Vote[]
   tags                  Tag[]
-
-  @@unique([communityId, index])
 }
 
 model User {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -42,6 +42,7 @@ async function seed() {
     TagType.SUGGESTION,
     TagType.GOVERNANCE,
     TagType.COMMUNITY,
+    TagType.NOUNS,
   ]) {
     const lowercaseType = type.toLowerCase();
     const label = lowercaseType[0].toUpperCase() + lowercaseType.slice(1);

--- a/scripts/retroPropLot.js
+++ b/scripts/retroPropLot.js
@@ -110,7 +110,6 @@ const formatIdea = async (idea, ideaTags, allVotes, allComments) => {
   );
 
   const formattedIdea = {
-    index: parseInt(idea.id),
     title: idea.title,
     description: idea.description,
     tldr: idea.tldr,


### PR DESCRIPTION
Removing the recently added index property, this is causing some issues when lilnouners try to add new ideas.

I'm also hiding the id from the UI so this doesn't become a problem going forward and they have been removed from the next iterations designs too.

This PR also fixes an issue with comment counts in the UI.