### PR TITLE
schema first pass

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,6 +1,3 @@
-// This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
-
 generator client {
   provider = "prisma-client-js"
   previewFeatures = ["filteredRelationCount"]
@@ -20,6 +17,46 @@ model Community {
   ideas       Idea[]
 }
 
+model Proposal {
+  id                    Int       @id @default(autoincrement())
+  createdAt             DateTime  @default(now())
+  updatedAt             DateTime  @updatedAt
+  title                 String    @db.VarChar(50)
+  description           String    @db.VarChar(1080)
+  createdBy             User      @relation(fields: [creatorId], references: [wallet])
+  creatorId             String
+  deleted               Boolean   @default(value: false)
+  ideaId                Int
+  idea                  Idea      @relation(fields: [ideaId], references: [id], onDelete: Cascade)
+  requests              OnChainRequest[]
+}
+
+// not sure if we want or need this right now
+model Collection {
+  id                    Int       @id @default(autoincrement())
+  createdAt             DateTime  @default(now())
+  updatedAt             DateTime  @updatedAt
+  title                 String    @db.VarChar(50)
+  ideas                 Idea[]
+  createdBy             User      @relation(fields: [creatorId], references: [wallet])
+  creatorId             String
+  deleted               Boolean   @default(value: false)
+}
+
+
+model OnChainRequest {
+  id                    Int       @id @default(autoincrement())
+  createdAt             DateTime  @default(now())
+  updatedAt             DateTime  @updatedAt
+  contractAddress       String
+  function              String
+  args                  String
+  value                 Int?
+  proposalId            Int
+  proposal              Proposal  @relation(fields: [proposalId], references: [id], onDelete: Cascade)
+}
+
+
 model Idea {
   id                    Int       @id @default(autoincrement())
   createdAt             DateTime  @default(now())
@@ -38,6 +75,8 @@ model Idea {
   comments              Comment[]
   votes                 Vote[]
   tags                  Tag[]
+  proposals             Proposal[]
+  collections           Collection[]
 }
 
 model User {
@@ -48,7 +87,11 @@ model User {
   ideas             Idea[]
   votes             Vote[]
   comments          Comment[]
+  collections       Collection[]
+  proposals         Proposal[]
 }
+
+// how do we want to keep track of edits?
 
 // direction
 // +1 for up


### PR DESCRIPTION
First pass at adding a new new models to the database.

The benefits of PropLot now seem to distill down to the following:
- introducing "Idea" and "proposal" relationships, so nouners can post ideas they want to see funded.
- getting temp checks of proposals before they become candidate proposals or go on chain. (drafts)
- creating a separate UI for candidate proposals (aside from the nouns sponsored UI that will be on the homepage)

Since not every community will have the v3 contract upgrades that Nouns are implementing, most of these new PropLot changes do not actually make much sense for all communities. For that reason, we will want to create new routes to house the "old" design for most communities, then have certain routes for the "new" designs that serve nouns and v3 contract.

I've assumed that we can keep "idea" so it serves the old model, but still serves this new proplot direction as well. I'm not 100% convinced this is the right direction, since most of the current "ideas" posted on proplot feel more like proposals than ideas (meaning they are "pre-proposals") rather than ideas that are hoping to solicit proposals from others. 

So maybe it makes sense to make a totally separate table for v2, and use the current "ideas" table to support some frozen proplotV1. 

Here's a small diagram I drew up of what I think the UX flow might look like.
<img width="819" alt="Screenshot 2023-06-04 at 10 19 53 AM" src="https://github.com/prop-lot/client/assets/12549482/3039d886-3c2e-408d-b7a6-6bce57eaed66">