### PR TITLE
Set default search range for ideas to "this month"

### DIFF
--- a/components/CommunityHome.tsx
+++ b/components/CommunityHome.tsx
@@ -198,6 +198,10 @@ export default function CommunityHome({
           </div>
         )}
         <div className="max-w-screen-xl mx-auto pt-8 space-y-4">
+          {appliedFilterTags?.length === 0 && (
+            <p className="text-sm text-gray-500">
+              Showing ideas posted this month, use the filters above to find more. </p>
+          )}
           {data?.propLot?.ideas?.map((idea: any, idx: number) => {
             return (
               <IdeaRow

--- a/services/ideas.ts
+++ b/services/ideas.ts
@@ -120,7 +120,7 @@ class IdeasService {
     communityId: number;
   }) {
     try {
-      const dateRange: any = DATE_FILTERS[date || "ALL_TIME"].filterFn();
+      const dateRange: any = DATE_FILTERS[date || "THIS_MONTH"].filterFn();
       const profileFilters: any = PROFILE_TAB_FILTERS[tab || "DEFAULT"](wallet);
       const ideas = await prisma.idea.findMany({
         where: {


### PR DESCRIPTION
We're currently returning all the ideas on every request to the list page, this is probably unnecessary and is likely contributing to larger data transfer costs. This PR is a pretty quick and simple change to default show ideas from the past month.

- Set default search to past month to limit data transfer.
- Add subheading letting users know the list is filtered.


![Screenshot 2024-01-20 at 13 05 20](https://github.com/prop-lot/client/assets/7782211/c4ca5350-e4b7-4bf1-b306-6e7ca8092627)
